### PR TITLE
Call .define_example_method on ExampleGroup's singleton class, which seems...

### DIFF
--- a/lib/rspec/example_steps.rb
+++ b/lib/rspec/example_steps.rb
@@ -16,7 +16,7 @@ RSpec::Core::ExampleGroup.send                       :include, RSpec::ExampleSte
 RSpec::Core::Reporter.send                           :include, RSpec::ExampleSteps::Reporter
 RSpec::Core::World.send                              :include, RSpec::ExampleSteps::World
 
-RSpec::Core::ExampleGroup.define_example_method :Steps, :with_steps => true
+RSpec::Core::ExampleGroup.singleton_class.define_example_method :Steps, :with_steps => true
 
 require 'rspec/example_steps/shared_steps'
 include RSpec::ExampleSteps::SharedSteps


### PR DESCRIPTION
... to be required in rspec 2.11 (without this change I get an undefined method error). Note how .define_example_method is defined in rspec/core/example_group
