### PR TITLE
Backward support for ruby < 1.9.2

### DIFF
--- a/lib/rspec/example_steps.rb
+++ b/lib/rspec/example_steps.rb
@@ -16,6 +16,20 @@ RSpec::Core::ExampleGroup.send                       :include, RSpec::ExampleSte
 RSpec::Core::Reporter.send                           :include, RSpec::ExampleSteps::Reporter
 RSpec::Core::World.send                              :include, RSpec::ExampleSteps::World
 
+
+# Taken from Ruby On Rails:
+# https://raw.github.com/rails/rails/3-0-stable/activesupport/lib/active_support/core_ext/kernel/singleton_class.rb
+module Kernel
+  # Returns the object's singleton class.
+  def singleton_class
+    class << self
+      self
+    end
+  end unless respond_to?(:singleton_class) # exists in 1.9.2
+
+end
+
+
 if RSpec::Core::ExampleGroup.singleton_class.respond_to?(:define_example_method)
   RSpec::Core::ExampleGroup.singleton_class.define_example_method :Steps, :with_steps => true
 else


### PR DESCRIPTION
Avoid below exception in ruby 1.8

/home/vagrant/rspec-example_steps/lib/rspec/example_steps.rb:20: undefined method `singleton_class' for RSpec::Core::ExampleGroup:Class (NoMethodError)
    from /usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in`gem_original_require'
    from /usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in `require'
    from /home/vagrant/rspec-example_steps/spec/spec_helper.rb:1
    from /usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in`gem_original_require'
    from /usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in `require'
    from /home/vagrant/rspec-example_steps/spec/example_steps_spec.rb:1
    from /var/lib/gems/1.8/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in`load'
    from /var/lib/gems/1.8/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in `load_spec_files'
    from /var/lib/gems/1.8/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in`each'
    from /var/lib/gems/1.8/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in `load_spec_files'
    from /var/lib/gems/1.8/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:22:in`run'
    from /var/lib/gems/1.8/gems/rspec-core-2.13.1/lib/rspec/core/runner.rb:80:in `run'
    from /var/lib/gems/1.8/gems/rspec-core-2.13.1/lib/rspec/core/runner.rb:17:in`autorun'
    from /usr/local/bin/rspec:19
