### PR TITLE
requiring rspec-core to avoid dependency issues

### DIFF
--- a/lib/rspec/example_steps.rb
+++ b/lib/rspec/example_steps.rb
@@ -1,3 +1,4 @@
+require 'rspec/core'
 require 'rspec/core/formatters/base_formatter'
 require 'rspec/core/formatters/documentation_formatter'
 require "rspec/core/example_group"


### PR DESCRIPTION
Resolving issue where anything run in test env bugs out with 
"uninitialized constant RSpec::Core::ExampleGroup::MetadataHashBuilder"
